### PR TITLE
use original address if IP can't be resolved

### DIFF
--- a/pvpn
+++ b/pvpn
@@ -86,6 +86,7 @@ do_args() {
                 shift;;
             -s|--first-ssh-hop)
                 ssh_ip="$(dig +short $2)"
+                ssh_ip="${ssh_ip:-$2}"
                 shift;;
 	    -p|--ssh-port)
 		ssh_port="$2"


### PR DESCRIPTION
Sometimes, VPN host doesn't have DNS name, so dig will return empty string and route will not be properly set up.